### PR TITLE
Move to application properties

### DIFF
--- a/src/main/resources/db/mysql.properties
+++ b/src/main/resources/db/mysql.properties
@@ -1,7 +1,1 @@
-database.url=jdbc:mysql://localhost/pioneer?useUnicode=true&characterEncoding=UTF-8&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&useSSL=false&serverTimezone=Europe/Kiev
-database.user=user
-database.password=password
-database.driver=com.mysql.cj.jdbc.Driver
 
-pool.initial=10
-pool.max=20


### PR DESCRIPTION
For me, it's better to move this properties to application.properties, because they are used for hole application itself and not depends on chosen db.